### PR TITLE
Use method modifers for DEMOLISH

### DIFF
--- a/t/lib/RunTestApp.pm
+++ b/t/lib/RunTestApp.pm
@@ -103,7 +103,8 @@ sub _build_child {
     }
 }
 
-sub DEMOLISH {
+sub DEMOLISH {}
+after DEMOLISH => sub {
     my ($self) = @_;
 
     return unless $self->has_child;
@@ -112,7 +113,7 @@ sub DEMOLISH {
     kill 'TERM',$child;
     diag "waitpid for child\n";
     waitpid($child,0);
-}
+};
 
 has reply_to => ( is => 'rw' );
 

--- a/t/lib/RunTestAppNoNet.pm
+++ b/t/lib/RunTestAppNoNet.pm
@@ -68,13 +68,14 @@ sub _build_child {
     }
 }
 
-sub DEMOLISH {
+sub DEMOLISH {}
+after DEMOLISH => sub {
     my ($self) = @_;
     return unless $self->has_child;
     my $child = $self->child;
     kill 'TERM',$child;
     diag "waitpid for child";
     waitpid($child,0);
-}
+};
 
 1;


### PR DESCRIPTION
Test::Routine::Common 0.25 provides stub BUILD/DEMOLISH methods for
modifying, which means the ones provided by the RunTestApp* roles
don't get applied.

Instead, provide stubs (for older Test::Routine), and do the actual
work in an 'after' modifier instead.