### PR TITLE
Wait until the trace directories show up in tests

### DIFF
--- a/t/lib/RunTestApp.pm
+++ b/t/lib/RunTestApp.pm
@@ -7,6 +7,7 @@ use BrokerTestApp;
 use Test::More;
 use Moose::Util 'apply_all_roles';
 use File::Temp 'tempdir';
+use Path::Class;
 
 my $mq;
 
@@ -98,7 +99,7 @@ sub _build_child {
     }
     else {
         diag "server started, waiting for spinup...";
-        sleep($ENV{NET_STOMP_DELAY}||5);
+        sleep 1 until dir($trace_dir)->children;
         return $pid;
     }
 }

--- a/t/lib/RunTestAppNoNet.pm
+++ b/t/lib/RunTestAppNoNet.pm
@@ -5,6 +5,7 @@ use BrokerTestApp;
 use Test::More;
 use Moose::Util 'apply_all_roles';
 use File::Temp 'tempdir';
+use Path::Class;
 use Net::Stomp::Producer;
 
 has producer => (
@@ -63,7 +64,7 @@ sub _build_child {
     }
     else {
         diag "server started, waiting for spinup...";
-        sleep($ENV{NET_STOMP_DELAY}||5);
+        sleep 1 until dir($trace_dir)->children;
         return $pid;
     }
 }


### PR DESCRIPTION
Instead of waiting for a specific amount of time, wait for the server
to actually create the trace subdirectories.